### PR TITLE
fixed first character is not highlighted when url at first of all texts

### DIFF
--- a/autolinklibrary/src/main/java/io/github/armcha/autolink/AutoLinkTextView.kt
+++ b/autolinklibrary/src/main/java/io/github/armcha/autolink/AutoLinkTextView.kt
@@ -134,7 +134,9 @@ class AutoLinkTextView(context: Context, attrs: AttributeSet? = null) : TextView
                     else -> {
                         val isUrl = it is MODE_URL
                         if (isUrl) {
-                            startPoint += 1
+                            if(startPoint > 0) {
+                                startPoint += 1
+                            }
                             group = group.trimStart()
                             if (urlProcessor != null) {
                                 val transformedUrl = urlProcessor?.invoke(group) ?: group


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/20433424/73923486-872cb000-48fd-11ea-8687-41ddb5ae888f.png)